### PR TITLE
Added a Static Retry Policy For Connection Timeout

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -150,10 +150,6 @@ public class AbfsConfiguration{
       DefaultValue = DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED)
   private boolean linearRetryForConnectionTimeoutEnabled;
 
-  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED,
-      DefaultValue = DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED)
-  private boolean staticRetryForConnectionTimeoutEnabled;
-
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT,
       DefaultValue = DEFAULT_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT)
   private int minBackoffIntervalForConnectionTimeout;
@@ -165,6 +161,14 @@ public class AbfsConfiguration{
   @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED,
       DefaultValue = DEFAULT_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED)
   private boolean linearRetryDoubleStepUpEnabled;
+
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED,
+      DefaultValue = DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED)
+  private boolean staticRetryForConnectionTimeoutEnabled;
+
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_STATIC_RETRY_INTERVAL,
+      DefaultValue = DEFAULT_STATIC_RETRY_INTERVAL)
+  private int staticRetryInterval;
 
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_BACKOFF_INTERVAL,
       DefaultValue = DEFAULT_BACKOFF_INTERVAL)
@@ -681,6 +685,10 @@ public class AbfsConfiguration{
 
   public boolean getStaticRetryForConnectionTimeoutEnabled() {
     return staticRetryForConnectionTimeoutEnabled;
+  }
+
+  public int getStaticRetryInterval() {
+    return staticRetryInterval;
   }
 
   public int getMinBackoffIntervalMillisecondsForConnectionTimeout() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -150,6 +150,10 @@ public class AbfsConfiguration{
       DefaultValue = DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED)
   private boolean linearRetryForConnectionTimeoutEnabled;
 
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED,
+      DefaultValue = DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED)
+  private boolean staticRetryForConnectionTimeoutEnabled;
+
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = AZURE_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT,
       DefaultValue = DEFAULT_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT)
   private int minBackoffIntervalForConnectionTimeout;
@@ -673,6 +677,10 @@ public class AbfsConfiguration{
 
   public boolean getLinearRetryForConnectionTimeoutEnabled() {
     return linearRetryForConnectionTimeoutEnabled;
+  }
+
+  public boolean getStaticRetryForConnectionTimeoutEnabled() {
+    return staticRetryForConnectionTimeoutEnabled;
   }
 
   public int getMinBackoffIntervalMillisecondsForConnectionTimeout() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -56,6 +56,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.azurebfs.services.LinearRetryPolicy;
+import org.apache.hadoop.fs.azurebfs.services.StaticRetryPolicy;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.Futures;
@@ -1645,6 +1646,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             new ExponentialRetryPolicy(abfsConfiguration))
         .withLinearRetryPolicy(
             new LinearRetryPolicy(abfsConfiguration))
+        .withStaticRetryPolicy(
+            new StaticRetryPolicy(abfsConfiguration))
         .withAbfsCounters(abfsCounters)
         .withAbfsPerfTracker(abfsPerfTracker)
         .build();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -49,6 +49,7 @@ public final class ConfigurationKeys {
   public static final String AZURE_MIN_BACKOFF_INTERVAL = "fs.azure.io.retry.min.backoff.interval";
   public static final String AZURE_MAX_BACKOFF_INTERVAL = "fs.azure.io.retry.max.backoff.interval";
   public static final String AZURE_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = "fs.azure.linear.retry.for.connection.timeout.enabled";
+  public static final String AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = "fs.azure.static.retry.for.connection.timeout.enabled";
   public static final String AZURE_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = "fs.azure.io.retry.min.backoff.interval.for.connection.timeout";
   public static final String AZURE_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = "fs.azure.io.retry.max.backoff.interval.for.connection.timeout";
   public static final String AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = "fs.azure.linear.retry.double.step.up.enabled";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -49,10 +49,11 @@ public final class ConfigurationKeys {
   public static final String AZURE_MIN_BACKOFF_INTERVAL = "fs.azure.io.retry.min.backoff.interval";
   public static final String AZURE_MAX_BACKOFF_INTERVAL = "fs.azure.io.retry.max.backoff.interval";
   public static final String AZURE_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = "fs.azure.linear.retry.for.connection.timeout.enabled";
-  public static final String AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = "fs.azure.static.retry.for.connection.timeout.enabled";
   public static final String AZURE_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = "fs.azure.io.retry.min.backoff.interval.for.connection.timeout";
   public static final String AZURE_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = "fs.azure.io.retry.max.backoff.interval.for.connection.timeout";
   public static final String AZURE_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = "fs.azure.linear.retry.double.step.up.enabled";
+  public static final String AZURE_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = "fs.azure.static.retry.for.connection.timeout.enabled";
+  public static final String AZURE_STATIC_RETRY_INTERVAL = "fs.azure.static.retry.interval";
   public static final String AZURE_BACKOFF_INTERVAL = "fs.azure.io.retry.backoff.interval";
   public static final String AZURE_MAX_IO_RETRIES = "fs.azure.io.retry.max.retries";
   public static final String AZURE_CUSTOM_TOKEN_FETCH_RETRY_COUNT = "fs.azure.custom.token.fetch.retry.count";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -41,6 +41,7 @@ public final class FileSystemConfigurations {
   public static final int DEFAULT_MIN_BACKOFF_INTERVAL = 3 * 1000;  // 3s
   public static final int DEFAULT_MAX_BACKOFF_INTERVAL = 30 * 1000;  // 30s
   public static final boolean DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = true;
+  public static final boolean DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = true;
   public static final int DEFAULT_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 500;  // 500ms
   public static final int DEFAULT_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 30 * 1000;  // 30s
   public static final boolean DEFAULT_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = true;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -42,6 +42,7 @@ public final class FileSystemConfigurations {
   public static final int DEFAULT_MAX_BACKOFF_INTERVAL = 30 * 1000;  // 30s
   public static final boolean DEFAULT_LINEAR_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = true;
   public static final boolean DEFAULT_STATIC_RETRY_FOR_CONNECTION_TIMEOUT_ENABLED = true;
+  public static final int DEFAULT_STATIC_RETRY_INTERVAL = 2 * 1000; // 2s
   public static final int DEFAULT_MIN_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 500;  // 500ms
   public static final int DEFAULT_MAX_BACKOFF_INTERVAL_FOR_CONNECTION_TIMEOUT = 30 * 1000;  // 30s
   public static final boolean DEFAULT_LINEAR_RETRY_DOUBLE_STEP_UP_ENABLED = true;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/InternalConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/InternalConstants.java
@@ -43,4 +43,8 @@ public final class InternalConstants {
    */
   public static final String CAPABILITY_SAFE_READAHEAD =
       "fs.azure.capability.readahead.safe";
+
+  public static final String EXPONENTIAL_RETRY_POLICY = "Exponential Retry Policy";
+  public static final String STATIC_RETRY_POLICY = "Static Retry Policy";
+  public static final String LINEAR_RETRY_POLICY = "Linear Retry Policy";
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContext.java
@@ -26,16 +26,19 @@ public class AbfsClientContext {
 
   private final ExponentialRetryPolicy exponentialRetryPolicy;
   private final LinearRetryPolicy linearRetryPolicy;
+  private final StaticRetryPolicy staticRetryPolicy;
   private final AbfsPerfTracker abfsPerfTracker;
   private final AbfsCounters abfsCounters;
 
   AbfsClientContext(
       ExponentialRetryPolicy exponentialRetryPolicy,
       LinearRetryPolicy linearRetryPolicy,
+      StaticRetryPolicy staticRetryPolicy,
       AbfsPerfTracker abfsPerfTracker,
       AbfsCounters abfsCounters) {
     this.exponentialRetryPolicy = exponentialRetryPolicy;
     this.linearRetryPolicy = linearRetryPolicy;
+    this.staticRetryPolicy = staticRetryPolicy;
     this.abfsPerfTracker = abfsPerfTracker;
     this.abfsCounters = abfsCounters;
   }
@@ -46,6 +49,10 @@ public class AbfsClientContext {
 
   public LinearRetryPolicy getLinearRetryPolicy() {
     return linearRetryPolicy;
+  }
+
+  public StaticRetryPolicy getStaticRetryPolicy() {
+    return staticRetryPolicy;
   }
 
   public AbfsPerfTracker getAbfsPerfTracker() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContextBuilder.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientContextBuilder.java
@@ -26,6 +26,7 @@ public class AbfsClientContextBuilder {
 
   private ExponentialRetryPolicy exponentialRetryPolicy;
   private LinearRetryPolicy linearRetryPolicy;
+  private StaticRetryPolicy staticRetryPolicy;
   private AbfsPerfTracker abfsPerfTracker;
   private AbfsCounters abfsCounters;
 
@@ -38,6 +39,12 @@ public class AbfsClientContextBuilder {
   public AbfsClientContextBuilder withLinearRetryPolicy(
       final LinearRetryPolicy linearRetryPolicy) {
     this.linearRetryPolicy = linearRetryPolicy;
+    return this;
+  }
+
+  public AbfsClientContextBuilder withStaticRetryPolicy(
+      final StaticRetryPolicy staticRetryPolicy) {
+    this.staticRetryPolicy = staticRetryPolicy;
     return this;
   }
 
@@ -62,6 +69,7 @@ public class AbfsClientContextBuilder {
     return new AbfsClientContext(
         exponentialRetryPolicy,
         linearRetryPolicy,
+        staticRetryPolicy,
         abfsPerfTracker,
         abfsCounters);
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -238,7 +238,7 @@ public class AbfsRestOperation {
         ++retryCount;
         tracingContext.setRetryCount(retryCount);
         long retryInterval = retryPolicy.getRetryInterval(retryCount);
-        LOG.debug("Rest operation {} failed. failureReason: {}, retryCount = {}, retryPolicy: {}, sleepInterval: {}",
+        LOG.debug("Rest operation {} failed with failureReason: {}. Retrying with retryCount = {}, retryPolicy: {} and sleepInterval: {}",
             operationType, failureReason, retryCount, getRetryPolicyStr(retryPolicy), retryInterval);
         Thread.sleep(retryInterval);
       } catch (InterruptedException ex) {
@@ -433,6 +433,11 @@ public class AbfsRestOperation {
     }
   }
 
+  /**
+   * Utility function to get the retry policy used as String for logging purpose.
+   * @param retryPolicy
+   * @return Retry Policy as String
+   */
   @VisibleForTesting
   String getRetryPolicyStr(final RetryPolicy retryPolicy) {
     if (retryPolicy instanceof StaticRetryPolicy) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -226,6 +226,7 @@ public class AbfsRestOperation {
       requestHeaders.add(httpHeader);
     }
 
+    // By Default Exponential Retry Policy Will be used
     retryCount = 0;
     retryPolicy = client.getExponentialRetryPolicy();
     LOG.debug("First execution of REST operation - {}", operationType);
@@ -233,9 +234,10 @@ public class AbfsRestOperation {
       try {
         ++retryCount;
         tracingContext.setRetryCount(retryCount);
-        LOG.debug("Retrying REST operation {}. RetryCount = {}",
-            operationType, retryCount);
-        Thread.sleep(retryPolicy.getRetryInterval(retryCount));
+        long retryInterval = retryPolicy.getRetryInterval(retryCount);
+        LOG.debug("Rest operation {} failed. failureReason: {}, retryCount = {}, retryPolicy: {}, sleepInterval: {}",
+            operationType, failureReason, retryCount, getRetryPolicyStr(), retryInterval);
+        Thread.sleep(retryInterval);
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
       }
@@ -426,5 +428,9 @@ public class AbfsRestOperation {
     if (abfsCounters != null) {
       abfsCounters.incrementCounter(statistic, value);
     }
+  }
+
+  private String getRetryPolicyStr() {
+    return "RetryPolicy";
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/StaticRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/StaticRetryPolicy.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
+import org.apache.hadoop.classification.VisibleForTesting;
+
+/**
+ * Linear Retry policy used by AbfsClient.
+ * */
+public class StaticRetryPolicy extends RetryPolicy {
+
+  private static final int STATIC_RETRY_INTERVAL = 2000; // 2s
+
+  /**
+   * Initializes a new instance of the {@link StaticRetryPolicy} class.
+   * @param maxIoRetries Maximum Retry Count Allowed
+   */
+  public StaticRetryPolicy(final int maxIoRetries) {
+    super(maxIoRetries);
+  }
+
+  /**
+   * Initializes a new instance of the {@link StaticRetryPolicy} class.
+   * @param conf The {@link AbfsConfiguration} from which to retrieve retry configuration.
+   */
+  public StaticRetryPolicy(AbfsConfiguration conf) {
+    this(conf.getMaxIoRetries());
+  }
+
+  /**
+   * Returns a constant backoff interval independent of retry count;
+   *
+   * @param retryCount The current retry attempt count.
+   * @return backoff Interval time
+   */
+  @Override
+  public long getRetryInterval(final int retryCount) {
+    return STATIC_RETRY_INTERVAL;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/StaticRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/StaticRetryPolicy.java
@@ -26,7 +26,12 @@ import org.apache.hadoop.classification.VisibleForTesting;
  * */
 public class StaticRetryPolicy extends RetryPolicy {
 
-  private static final int STATIC_RETRY_INTERVAL = 2000; // 2s
+  private static final int STATIC_RETRY_INTERVAL_DEFAULT = 2000; // 2s
+
+  /**
+   * Represents the constant retry interval to be used with Static Retry Policy
+   */
+  private int retryInterval;
 
   /**
    * Initializes a new instance of the {@link StaticRetryPolicy} class.
@@ -34,6 +39,7 @@ public class StaticRetryPolicy extends RetryPolicy {
    */
   public StaticRetryPolicy(final int maxIoRetries) {
     super(maxIoRetries);
+    this.retryInterval = STATIC_RETRY_INTERVAL_DEFAULT;
   }
 
   /**
@@ -42,6 +48,7 @@ public class StaticRetryPolicy extends RetryPolicy {
    */
   public StaticRetryPolicy(AbfsConfiguration conf) {
     this(conf.getMaxIoRetries());
+    this.retryInterval = conf.getStaticRetryInterval();
   }
 
   /**
@@ -52,6 +59,6 @@ public class StaticRetryPolicy extends RetryPolicy {
    */
   @Override
   public long getRetryInterval(final int retryCount) {
-    return STATIC_RETRY_INTERVAL;
+    return retryInterval;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
@@ -56,6 +56,9 @@ import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.E
 import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.X_HTTP_METHOD_OVERRIDE;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpQueryParams.QUERY_PARAM_ACTION;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpQueryParams.QUERY_PARAM_POSITION;
+import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.EXPONENTIAL_RETRY_POLICY;
+import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.LINEAR_RETRY_POLICY;
+import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.STATIC_RETRY_POLICY;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_ABFS_ACCOUNT_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.TEST_CONFIGURATION_FILE_NAME;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -354,5 +357,19 @@ public class ITestAbfsRestOperation extends AbstractAbfsIntegrationTest {
     default:
       break;
     }
+  }
+
+  @Test
+  public void testRetryPolicyString() throws Exception {
+    // Gets the AbfsRestOperation.
+    AbfsRestOperation op = getRestOperation();
+    RetryPolicy retryPolicy = new LinearRetryPolicy(10);
+    Assertions.assertThat(op.getRetryPolicyStr(retryPolicy)).isEqualTo(LINEAR_RETRY_POLICY);
+
+    retryPolicy = new StaticRetryPolicy(10);
+    Assertions.assertThat(op.getRetryPolicyStr(retryPolicy)).isEqualTo(STATIC_RETRY_POLICY);
+
+    retryPolicy = new ExponentialRetryPolicy(10);
+    Assertions.assertThat(op.getRetryPolicyStr(retryPolicy)).isEqualTo(EXPONENTIAL_RETRY_POLICY);
   }
 }


### PR DESCRIPTION
Follow up to the PR: https://github.com/apache/hadoop/pull/5711

This PR introduces a new Static Retry policy to be used only in case of connection timeout failures.
This Static Retry Policy will have a constant retry interval independent of retry count.
Value of the constant is kept at 2s...

This also introduces a new config: "fs.azure.static.retry.for.connection.timeout.enabled" by default set to true.

If this config is true, Static Retry policy will be used always irrespective of the linear retry config value.
If this is false, we will check for linear retry config value and use accordingly